### PR TITLE
unset PYTHONPATH in cvmfs tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,8 +111,9 @@ jobs:
           run: |
             yum -y install glibc-headers glibc-devel unzip
             eval $(/cvmfs/icecube.opensciencegrid.org/${{matrix.cvmfs}}/setup.sh)
+            unset PYTHONPATH
             export PATH=${HOME}/.local/bin:${PATH}
-            pip install --upgrade --user meson ninja 'pytest>=7,<8' pytest-tap
+            pip install --upgrade --user meson ninja pytest pytest-tap
             CMAKE_PREFIX_PATH=${SROOT} BOOST_ROOT=${SROOT} meson setup /nuflux/build /nuflux
             meson test -C/nuflux/build
       - name: Copy TestLog
@@ -143,7 +144,8 @@ jobs:
           run: |
             yum -y install glibc-headers glibc-devel
             eval $(/cvmfs/icecube.opensciencegrid.org/${{matrix.cvmfs}}/setup.sh)
-            python3 -m pip install --upgrade --user pip 'pytest>=7,<8'
+            unset PYTHONPATH
+            python3 -m pip install --upgrade --user pip pytest
             BOOST_ROOT=${SROOT} python3 -m pip install --user --verbose /nf
             python3 -m pytest /nf --junit-xml=/nf/test-results-pyproject-cvmfs-${{matrix.cvmfs}}.junit.xml
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -109,7 +109,8 @@ jobs:
           image: centos:centos7.9.2009
           run: |
             eval $(/cvmfs/icecube.opensciencegrid.org/${{matrix.cvmfs}}/setup.sh)
-            python3 -m pip install --user 'pytest>=7,<8' /nuflux/nuflux-*-${{matrix.python-tag}}-*.whl
+            unset PYTHONPATH
+            python3 -m pip install --user pytest /nuflux/nuflux-*-${{matrix.python-tag}}-*.whl
             python3 /nuflux/tests/test_fluxes.py --junit-xml=test-results-cibw-cvmfs-${{ matrix.cvmfs }}.junit.xml
   upload_pypi:
     needs: [cvmfs_test_wheel, test_wheels, build_sdist]


### PR DESCRIPTION
PYTHONPATH appears to be not only unnescessary but activly messing up the tests
because the packages in system site-packages are old and incompatible with the
latest version of pytest. Having system site-packages in PYTHONPATH causes
them to be loaded first overriding what it is in .local/
